### PR TITLE
Increase test coverage threshold to 60%.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "config": {
     "travis-cov": {
-      "threshold": 50
+      "threshold": 60
     },
     "blanket": {
       "pattern": "//^((?!/node_modules/)(?!/test/).)*$/ig"


### PR DESCRIPTION
We’re currently at 60% test coverage, so this forces us to write more tests whenever anything new is added.

Also:

I created a pull request for this because I’d like to capture a pull request merge event for tests, so we can use it [like this push event](https://github.com/NodeDC/node-dc-irc/blob/9e09d6b48694fd255397da9f747738b29827fd61/test/snapshots/github.push.json).

Myself or @joshfinnie will need to capture the console output of the Heroku logs at the time this is merged so we can store it — the only caveat is that I can’t merge this (since I’d like to add a test assertion which will catch #2).
